### PR TITLE
fix: auto migrate error ErrMissingShardingKey

### DIFF
--- a/dialector.go
+++ b/dialector.go
@@ -49,7 +49,11 @@ func (m ShardingMigrator) AutoMigrate(dst ...interface{}) error {
 	}
 
 	if len(noShardingDsts) > 0 {
-		if err := m.Migrator.AutoMigrate(noShardingDsts...); err != nil {
+		tx := stmt.DB.Session(&gorm.Session{})
+		tx.Statement.Settings.Store(ShardingIgnoreStoreKey, nil)
+		defer tx.Statement.Settings.Delete(ShardingIgnoreStoreKey)
+
+		if err := m.dialector.Migrator(tx).AutoMigrate(noShardingDsts...); err != nil {
 			return err
 		}
 	}

--- a/sharding_test.go
+++ b/sharding_test.go
@@ -171,6 +171,10 @@ func TestMigrate(t *testing.T) {
 	tables, _ = db.Migrator().GetTables()
 	sort.Strings(tables)
 	assert.Equal(t, tables, targetTables)
+
+	// auto migrate again
+	err := db.AutoMigrate(&Order{}, &Category{})
+	assert.Equal(t, err, nil)
 }
 
 func TestInsert(t *testing.T) {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
When `DoubleWrite` is enabled, we need to query database schema information by table name during the migration. In this case, we should use the original `ConnPool`.
https://github.com/go-gorm/postgres/blob/master/migrator.go#L218

### User Case Description

<!-- Your use case -->
