### PR TITLE
feat: trace sharding log

### DIFF
--- a/sharding_test.go
+++ b/sharding_test.go
@@ -378,7 +378,7 @@ func TestReadWriteSplitting(t *testing.T) {
 	assert.Equal(t, "iPhone", order.Product)
 }
 
-func TestTraceSQL(t *testing.T) {
+func TestTraceSqlLog(t *testing.T) {
 	tx := db.Session(&gorm.Session{NewDB: true})
 	// we can set mode to view logs
 	// tx.Logger = tx.Logger.LogMode(logger.Info)

--- a/sharding_test.go
+++ b/sharding_test.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/bwmarrin/snowflake"
@@ -375,6 +376,27 @@ func TestReadWriteSplitting(t *testing.T) {
 
 	dbWrite.Table("orders_0").Where("user_id", 100).Find(&order)
 	assert.Equal(t, "iPhone", order.Product)
+}
+
+func TestTraceSQL(t *testing.T) {
+	tx := db.Session(&gorm.Session{NewDB: true})
+	// we can set mode to view logs
+	// tx.Logger = tx.Logger.LogMode(logger.Info)
+
+	expected := `INSERT INTO orders_0 ("user_id", "product", id) VALUES`
+
+	wg := sync.WaitGroup{}
+	var mockSql string
+	tx.Callback().Create().After("gorm:sharding:mocksql").Register("gorm:TestTraceSQL", func(d *gorm.DB) {
+		mockSql = d.Statement.SQL.String()
+		tx.Callback().Create().Remove("gorm:TestTraceSQL")
+		wg.Done()
+	})
+
+	wg.Add(1)
+	tx.Create(&Order{UserID: 1000, Product: "TestTraceSQL"})
+	wg.Wait()
+	assert.Equal(t, expected, mockSql[0:len(expected)])
 }
 
 func assertQueryResult(t *testing.T, expected string, tx *gorm.DB) {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
Even if we use the sharding model, the log will only print the original sql.
This feature is used to print the sql log of the actual execution.
This is similar to `LastQuery`, the difference is that in a model with an associated relationship, the log will be printed multiple times, while `LastQuery` records the last time.
### User Case Description

<!-- Your use case -->
