### PR TITLE
fix: create multiple record error

### DIFF
--- a/sharding.go
+++ b/sharding.go
@@ -285,7 +285,8 @@ func (s *Sharding) resolve(query string, args ...interface{}) (ftQuery, stQuery,
 	var condition sqlparser.Expr
 	var isInsert bool
 	var insertNames []*sqlparser.Ident
-	var insertValues []sqlparser.Expr
+	var inserExpressions []*sqlparser.Exprs
+	var insertStmt *sqlparser.InsertStatement
 
 	switch stmt := expr.(type) {
 	case *sqlparser.SelectStatement:
@@ -302,7 +303,8 @@ func (s *Sharding) resolve(query string, args ...interface{}) (ftQuery, stQuery,
 		table = stmt.TableName
 		isInsert = true
 		insertNames = stmt.ColumnNames
-		insertValues = stmt.Expressions[0].Exprs
+		inserExpressions = stmt.Expressions
+		insertStmt = stmt
 	case *sqlparser.UpdateStatement:
 		condition = stmt.Condition
 		table = stmt.TableName
@@ -319,23 +321,101 @@ func (s *Sharding) resolve(query string, args ...interface{}) (ftQuery, stQuery,
 		return
 	}
 
-	var value interface{}
-	var id int64
-	var keyFind bool
+	var suffix string
 	if isInsert {
-		value, id, keyFind, err = s.insertValue(r.ShardingKey, insertNames, insertValues, args...)
-		if err != nil {
-			return
+		var newTable *sqlparser.TableName
+		for _, inserExpression := range inserExpressions {
+			var value interface{}
+			var id int64
+			var keyFind bool
+			columnNames := insertNames
+			insertValues := inserExpression.Exprs
+			value, id, keyFind, err = s.insertValue(r.ShardingKey, insertNames, insertValues, args...)
+			if err != nil {
+				return
+			}
+
+			var subSuffix string
+			subSuffix, err = getSuffix(value, id, keyFind, r)
+			if err != nil {
+				return
+			}
+
+			if suffix != "" && suffix != subSuffix {
+				err = fmt.Errorf("can not insert different suffix table in one query (%s,%s)", tableName+suffix, tableName+subSuffix)
+				return
+			}
+
+			suffix = subSuffix
+
+			newTable = &sqlparser.TableName{Name: &sqlparser.Ident{Name: tableName + suffix}}
+
+			fillID := true
+			if isInsert {
+				for _, name := range insertNames {
+					if name.Name == "id" {
+						fillID = false
+						break
+					}
+				}
+				if fillID {
+					tblIdx, err := strconv.Atoi(strings.Replace(suffix, "_", "", 1))
+					if err != nil {
+						return ftQuery, stQuery, tableName, err
+					}
+					id := r.PrimaryKeyGeneratorFn(int64(tblIdx))
+					columnNames = append(insertNames, &sqlparser.Ident{Name: "id"})
+					insertValues = append(insertValues, &sqlparser.NumberLit{Value: strconv.FormatInt(id, 10)})
+				}
+			}
+
+			if fillID {
+				insertStmt.ColumnNames = columnNames
+				inserExpression.Exprs = insertValues
+			}
 		}
+
+		ftQuery = insertStmt.String()
+		insertStmt.TableName = newTable
+		stQuery = insertStmt.String()
+
 	} else {
+		var value interface{}
+		var id int64
+		var keyFind bool
 		value, id, keyFind, err = s.nonInsertValue(r.ShardingKey, condition, args...)
 		if err != nil {
 			return
 		}
+
+		suffix, err = getSuffix(value, id, keyFind, r)
+		if err != nil {
+			return
+		}
+
+		newTable := &sqlparser.TableName{Name: &sqlparser.Ident{Name: tableName + suffix}}
+
+		switch stmt := expr.(type) {
+		case *sqlparser.SelectStatement:
+			ftQuery = stmt.String()
+			stmt.FromItems = newTable
+			stmt.OrderBy = replaceOrderByTableName(stmt.OrderBy, tableName, newTable.Name.Name)
+			stQuery = stmt.String()
+		case *sqlparser.UpdateStatement:
+			ftQuery = stmt.String()
+			stmt.TableName = newTable
+			stQuery = stmt.String()
+		case *sqlparser.DeleteStatement:
+			ftQuery = stmt.String()
+			stmt.TableName = newTable
+			stQuery = stmt.String()
+		}
 	}
 
-	var suffix string
+	return
+}
 
+func getSuffix(value interface{}, id int64, keyFind bool, r Config) (suffix string, err error) {
 	if keyFind {
 		suffix, err = r.ShardingAlgorithm(value)
 		if err != nil {
@@ -348,52 +428,6 @@ func (s *Sharding) resolve(query string, args ...interface{}) (ftQuery, stQuery,
 		}
 		suffix = r.ShardingAlgorithmByPrimaryKey(id)
 	}
-
-	newTable := &sqlparser.TableName{Name: &sqlparser.Ident{Name: tableName + suffix}}
-
-	fillID := true
-	if isInsert {
-		for _, name := range insertNames {
-			if name.Name == "id" {
-				fillID = false
-				break
-			}
-		}
-		if fillID {
-			tblIdx, err := strconv.Atoi(strings.Replace(suffix, "_", "", 1))
-			if err != nil {
-				return ftQuery, stQuery, tableName, err
-			}
-			id := r.PrimaryKeyGeneratorFn(int64(tblIdx))
-			insertNames = append(insertNames, &sqlparser.Ident{Name: "id"})
-			insertValues = append(insertValues, &sqlparser.NumberLit{Value: strconv.FormatInt(id, 10)})
-		}
-	}
-
-	switch stmt := expr.(type) {
-	case *sqlparser.InsertStatement:
-		if fillID {
-			stmt.ColumnNames = insertNames
-			stmt.Expressions[0].Exprs = insertValues
-		}
-		ftQuery = stmt.String()
-		stmt.TableName = newTable
-		stQuery = stmt.String()
-	case *sqlparser.SelectStatement:
-		ftQuery = stmt.String()
-		stmt.FromItems = newTable
-		stmt.OrderBy = replaceOrderByTableName(stmt.OrderBy, tableName, newTable.Name.Name)
-		stQuery = stmt.String()
-	case *sqlparser.UpdateStatement:
-		ftQuery = stmt.String()
-		stmt.TableName = newTable
-		stQuery = stmt.String()
-	case *sqlparser.DeleteStatement:
-		ftQuery = stmt.String()
-		stmt.TableName = newTable
-		stQuery = stmt.String()
-	}
-
 	return
 }
 

--- a/sharding.go
+++ b/sharding.go
@@ -16,6 +16,7 @@ import (
 var (
 	ErrMissingShardingKey = errors.New("sharding key or id required, and use operator =")
 	ErrInvalidID          = errors.New("invalid id format")
+	ErrInsertDiffSuffix   = errors.New("can not insert different suffix table in one query ")
 )
 
 var (
@@ -342,7 +343,7 @@ func (s *Sharding) resolve(query string, args ...interface{}) (ftQuery, stQuery,
 			}
 
 			if suffix != "" && suffix != subSuffix {
-				err = fmt.Errorf("can not insert different suffix table in one query (%s,%s)", tableName+suffix, tableName+subSuffix)
+				err = ErrInsertDiffSuffix
 				return
 			}
 

--- a/sharding_test.go
+++ b/sharding_test.go
@@ -202,6 +202,11 @@ func TestInsertManyWithFillID(t *testing.T) {
 	assert.Equal(t, toDialect(expected), lastQuery)
 }
 
+func TestInsertDiffSuffix(t *testing.T) {
+	err := db.Create([]Order{{UserID: 100, Product: "Mac"}, {UserID: 101, Product: "Mac Pro"}}).Error
+	assert.Equal(t, ErrInsertDiffSuffix, err)
+}
+
 func TestSelect1(t *testing.T) {
 	tx := db.Model(&Order{}).Where("user_id", 101).Where("id", node.Generate().Int64()).Find(&[]Order{})
 	assertQueryResult(t, `SELECT * FROM orders_1 WHERE "user_id" = $1 AND "id" = $2`, tx)

--- a/sharding_test.go
+++ b/sharding_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -190,16 +191,12 @@ func TestFillID(t *testing.T) {
 }
 
 func TestInsertManyWithFillID(t *testing.T) {
-	node, _ := snowflake.NewNode(0)
-	sfid1 := node.Generate().Int64()
-	sfid2 := node.Generate().Int64()
-
 	err := db.Create([]Order{{UserID: 100, Product: "Mac"}, {UserID: 100, Product: "Mac Pro"}}).Error
 	assert.Equal(t, err, nil)
 
-	expected := fmt.Sprintf(`INSERT INTO orders_0 ("user_id", "product", id) VALUES ($1, $2, %d), ($3, $4, %d) RETURNING "id"`, sfid1, sfid2)
+	expected := `INSERT INTO orders_0 ("user_id", "product", id) VALUES ($1, $2, $sfid), ($3, $4, $sfid) RETURNING "id"`
 	lastQuery := middleware.LastQuery()
-	assert.Equal(t, toDialect(expected), lastQuery)
+	assertSfidQueryResult(t, toDialect(expected), lastQuery)
 }
 
 func TestInsertDiffSuffix(t *testing.T) {
@@ -413,4 +410,33 @@ func toDialect(sql string) string {
 		sql = strings.ReplaceAll(sql, " RETURNING `id`", "")
 	}
 	return sql
+}
+
+// skip $sfid compare
+func assertSfidQueryResult(t *testing.T, expected, lastQuery string) {
+	t.Helper()
+
+	node, _ := snowflake.NewNode(0)
+	sfid := node.Generate().Int64()
+	sfidLen := len(strconv.Itoa(int(sfid)))
+	re := regexp.MustCompile(`\$sfid`)
+
+	for {
+		match := re.FindStringIndex(expected)
+		if len(match) == 0 {
+			break
+		}
+
+		start := match[0]
+		end := match[1]
+
+		if len(lastQuery) < start+sfidLen {
+			break
+		}
+
+		sfid := lastQuery[start : start+sfidLen]
+		expected = expected[:start] + sfid + expected[end:]
+	}
+
+	assert.Equal(t, toDialect(expected), lastQuery)
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

```sql
-- before
INSERT INTO orders_0 ("user_id", "product", id) VALUES ($1, $2, 1522924480932872192), ($3, $4) RETURNING "id"
-- after
INSERT INTO orders_0 ("user_id", "product", id) VALUES ($1, $2, 1522924480932872192), ($3, $4, 1522924480932872193) RETURNING "id"
```
It's gives an `ErrInsertDiffSuffix` when inserting a different suffix table, mainly used for `Create` to auto-save associations


### User Case Description

<!-- Your use case -->
