### PR TITLE
When the table suffix is non numeric, the insertion operation will report an error when generating the primary key ID

### DIFF
--- a/sharding.go
+++ b/sharding.go
@@ -360,9 +360,10 @@ func (s *Sharding) resolve(query string, args ...interface{}) (ftQuery, stQuery,
 					}
 				}
 				if fillID {
-					tblIdx, err := strconv.Atoi(strings.Replace(suffix, "_", "", 1))
+					suffixWords := strings.Replace(suffix, "_", "", 1)
+					tblIdx, err := strconv.Atoi(suffixWords)
 					if err != nil {
-						return ftQuery, stQuery, tableName, err
+						tblIdx = int(crc32.ChecksumIEEE([]byte(suffixWords))) % int(r.NumberOfShards)
 					}
 					id := r.PrimaryKeyGeneratorFn(int64(tblIdx))
 					columnNames = append(insertNames, &sqlparser.Ident{Name: "id"})


### PR DESCRIPTION
Solving the problem of generating primary key errors when the table suffix is a string
eg：
```
type FileRecord struct {
	ID        int64  `gorm:"primary_key;column:id"`
	Project   string `gorm:"column:project"`
	UserID    int64  `gorm:"column:user_id"`
	ProductID int64  `gorm:"column:product_id"`
}

func (FileRecord) TableName() string {
	return "file_record"
}

middleware := sharding.Register(sharding.Config{
		ShardingKey: "project",
		ShardingAlgorithm: func(value interface{}) (suffix string, err error) {
			if project, ok := value.(string); ok {
				return fmt.Sprintf("_%s", project), nil
			}
			return "", errors.New("invalid project")
		},
		NumberOfShards: 8,
		//PrimaryKeyGenerator: sharding.PKSnowflake,
	}, "file_record")
	db.Use(middleware)

	// 插入数据
	err = db.Create(&FileRecord{UserID: 221, Project: "a"}).Error
	if err != nil {
		fmt.Println(err)
	}
```
Error message: strconv.Atoi: parsing "a": invalid syntax