### PR TITLE
fix conn data race

### DIFF
--- a/sharding.go
+++ b/sharding.go
@@ -33,6 +33,8 @@ type Sharding struct {
 
 	_config Config
 	_tables []any
+
+	mutex sync.RWMutex
 }
 
 // Config specifies the configuration for sharding.
@@ -266,8 +268,14 @@ func (s *Sharding) switchConn(db *gorm.DB) {
 	// When DoubleWrite is enabled, we need to query database schema
 	// information by table name during the migration.
 	if _, ok := db.Get(ShardingIgnoreStoreKey); !ok {
-		s.ConnPool = &ConnPool{ConnPool: db.Statement.ConnPool, sharding: s}
-		db.Statement.ConnPool = s.ConnPool
+		s.mutex.Lock()
+		if db.Statement.ConnPool != nil {
+			if _, ok = db.Statement.ConnPool.(ConnPool); !ok {
+				s.ConnPool = &ConnPool{ConnPool: db.Statement.ConnPool, sharding: s}
+				db.Statement.ConnPool = s.ConnPool
+			}
+		}
+		s.mutex.Unlock()
 	}
 }
 

--- a/sharding.go
+++ b/sharding.go
@@ -270,10 +270,8 @@ func (s *Sharding) switchConn(db *gorm.DB) {
 	if _, ok := db.Get(ShardingIgnoreStoreKey); !ok {
 		s.mutex.Lock()
 		if db.Statement.ConnPool != nil {
-			if _, ok = db.Statement.ConnPool.(ConnPool); !ok {
-				s.ConnPool = &ConnPool{ConnPool: db.Statement.ConnPool, sharding: s}
-				db.Statement.ConnPool = s.ConnPool
-			}
+			s.ConnPool = &ConnPool{ConnPool: db.Statement.ConnPool, sharding: s}
+			db.Statement.ConnPool = s.ConnPool
 		}
 		s.mutex.Unlock()
 	}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

Fix conn DARA RACE issue. There are some related issues like #96.

### User Case Description

<!-- Your use case -->

I use this package for sharding bill table. It runs normally on test environment, but occur DATA RACE issue on online environment. 

I write unit test for this issue:

- sharding_test.go
```go
func TestDataRace(t *testing.T) {
	ctx, cancel := context.WithCancel(context.Background())
	ch := make(chan error)

	for i := 0; i < 2; i++ {
		go func() {
			for {
				select {
				case <-ctx.Done():
					return
				default:
					err := db.Model(&Order{}).Where("user_id", 100).Find(&[]Order{}).Error
					if err != nil {
						ch <- err
						return
					}
				}
			}
		}()
	}

	select {
	case <-time.After(time.Millisecond * 50):
		cancel()
	case err := <-ch:
		cancel()
		t.Fatal(err)
	}
}
```

Run this unit test on main branch with `go test --race -count=1 -v --run=TestDataRace`, it will output:

```
=== RUN   TestDataRace
==================
WARNING: DATA RACE
Write at 0x00c0000b3048 by goroutine 15:
  command-line-arguments.(*Sharding).switchConn()
      /Users/liangjunmo/workspace/gorm-sharding/sharding.go:268 +0x168
  command-line-arguments.(*Sharding).switchConn-fm()
      <autogenerated>:1 +0x44
  gorm.io/gorm.(*processor).Execute()
      /Users/liangjunmo/.gvm/pkgsets/go1.19.9/global/pkg/mod/gorm.io/gorm@v1.25.1/callbacks.go:130 +0xbe1
  gorm.io/gorm.(*DB).Find()
      /Users/liangjunmo/.gvm/pkgsets/go1.19.9/global/pkg/mod/gorm.io/gorm@v1.25.1/finisher_api.go:172 +0x238
  command-line-arguments.TestDataRace.func1()
      /Users/liangjunmo/workspace/gorm-sharding/sharding_test.go:413 +0x20d

Previous write at 0x00c0000b3048 by goroutine 14:
  command-line-arguments.(*Sharding).switchConn()
      /Users/liangjunmo/workspace/gorm-sharding/sharding.go:268 +0x168
  command-line-arguments.(*Sharding).switchConn-fm()
      <autogenerated>:1 +0x44
  gorm.io/gorm.(*processor).Execute()
      /Users/liangjunmo/.gvm/pkgsets/go1.19.9/global/pkg/mod/gorm.io/gorm@v1.25.1/callbacks.go:130 +0xbe1
  gorm.io/gorm.(*DB).Find()
      /Users/liangjunmo/.gvm/pkgsets/go1.19.9/global/pkg/mod/gorm.io/gorm@v1.25.1/finisher_api.go:172 +0x238
  command-line-arguments.TestDataRace.func1()
      /Users/liangjunmo/workspace/gorm-sharding/sharding_test.go:413 +0x20d

Goroutine 15 (running) created at:
  command-line-arguments.TestDataRace()
      /Users/liangjunmo/workspace/gorm-sharding/sharding_test.go:407 +0x87
  testing.tRunner()
      /Users/liangjunmo/.gvm/gos/go1.19.9/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /Users/liangjunmo/.gvm/gos/go1.19.9/src/testing/testing.go:1493 +0x47

Goroutine 14 (running) created at:
  command-line-arguments.TestDataRace()
      /Users/liangjunmo/workspace/gorm-sharding/sharding_test.go:407 +0x87
  testing.tRunner()
      /Users/liangjunmo/.gvm/gos/go1.19.9/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /Users/liangjunmo/.gvm/gos/go1.19.9/src/testing/testing.go:1493 +0x47
==================
    testing.go:1319: race detected during execution of test
--- FAIL: TestDataRace (0.05s)
=== CONT
    testing.go:1319: race detected during execution of test
FAIL
FAIL	command-line-arguments	0.867s
FAIL
```