### PR TITLE
修复panic: interface conversion: sharding.ShardingMigrator is not migrato…

### DIFF
--- a/dialector.go
+++ b/dialector.go
@@ -2,6 +2,8 @@ package sharding
 
 import (
 	"fmt"
+	"gorm.io/gorm/migrator"
+	"gorm.io/gorm/schema"
 
 	"gorm.io/gorm"
 )
@@ -59,6 +61,11 @@ func (m ShardingMigrator) AutoMigrate(dst ...any) error {
 	}
 
 	return nil
+}
+
+// BuildIndexOptions build index options
+func (m ShardingMigrator) BuildIndexOptions(opts []schema.IndexOption, stmt *gorm.Statement) (results []interface{}) {
+	return m.Migrator.(migrator.BuildIndexOptionsInterface).BuildIndexOptions(opts, stmt)
 }
 
 func (m ShardingMigrator) DropTable(dst ...any) error {


### PR DESCRIPTION
…r.BuildIndexOptionsInterface: missing method BuildIndexOptions

修复有gorm:index标签时报错的问题
fix：https://github.com/go-gorm/sharding/issues/97

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ √] Do only one thing
- [ ] Non breaking API changes
- [ ] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->
