### PR TITLE
Fixed the return result of ShardingSuffixs cannot be correctly matched when using string type table suffix.

### DIFF
--- a/sharding.go
+++ b/sharding.go
@@ -389,9 +389,9 @@ func (s *Sharding) resolve(query string, args ...any) (ftQuery, stQuery, tableNa
 				suffixWord := strings.Replace(suffix, "_", "", 1)
 				tblIdx, err := strconv.Atoi(suffixWord)
 				if err != nil {
-					tblIdx = slices.Index(r.ShardingSuffixs(), suffixWord)
+					tblIdx = slices.Index(r.ShardingSuffixs(), suffix)
 					if tblIdx == -1 {
-						return ftQuery, stQuery, tableName, errors.New("table suffix '" + suffixWord + "' is not in ShardingSuffixs. In order to generate the primary key, ShardingSuffixs should include all table suffixes")
+						return ftQuery, stQuery, tableName, errors.New("table suffix '" + suffix + "' is not in ShardingSuffixs. In order to generate the primary key, ShardingSuffixs should include all table suffixes")
 					}
 					//return ftQuery, stQuery, tableName, err
 				}


### PR DESCRIPTION
…ot be correctly matched when using string type table suffix.

Fixed the problem that the return result of ShardingSuffixs cannot be correctly matched when using string type table suffix.

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->
