### PR TITLE
feat: support logging sharding stQuery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?


support logging sharding sql


### User Case Description

We use go-gorm/sharding to split large tables and record every SQL query in our log system for quick bug fixes. However, currently, with go-gorm/sharding, the GORM logger only prints the original SQL and does not print the sharded SQL.