### PR TITLE
id支持其他类型的分片

### DIFF
--- a/sharding.go
+++ b/sharding.go
@@ -421,7 +421,7 @@ func (s *Sharding) resolve(query string, args ...any) (ftQuery, stQuery, tableNa
 		var value any
 		var id int64
 		var keyFind bool
-		value, id, keyFind, err = s.nonInsertValue(r.ShardingKey, condition, args...)
+		value, id, keyFind, err = s.nonInsertValue(r, condition, args...)
 		if err != nil {
 			return
 		}
@@ -501,7 +501,7 @@ func (s *Sharding) insertValue(key string, names []*sqlparser.Ident, exprs []sql
 	return
 }
 
-func (s *Sharding) nonInsertValue(key string, condition sqlparser.Expr, args ...any) (value any, id int64, keyFind bool, err error) {
+func (s *Sharding) nonInsertValue(r Config, condition sqlparser.Expr, args ...any) (value any, id int64, keyFind bool, err error) {
 	err = sqlparser.Walk(sqlparser.VisitFunc(func(node sqlparser.Node) error {
 		if n, ok := node.(*sqlparser.BinaryExpr); ok {
 			x, ok := n.X.(*sqlparser.Ident)
@@ -512,7 +512,7 @@ func (s *Sharding) nonInsertValue(key string, condition sqlparser.Expr, args ...
 				}
 			}
 			if ok {
-				if x.Name == key && n.Op == sqlparser.EQ {
+				if x.Name == r.ShardingKey && n.Op == sqlparser.EQ {
 					keyFind = true
 					switch expr := n.Y.(type) {
 					case *sqlparser.BindExpr:
@@ -529,12 +529,26 @@ func (s *Sharding) nonInsertValue(key string, condition sqlparser.Expr, args ...
 					switch expr := n.Y.(type) {
 					case *sqlparser.BindExpr:
 						v := args[expr.Pos]
+						if r.ShardingAlgorithm != nil {
+							keyFind = true
+							if value == nil {
+								value = v
+							}
+							return nil
+						}
 						var ok bool
 						if id, ok = v.(int64); !ok {
 							return fmt.Errorf("ID should be int64 type")
 						}
 					case *sqlparser.NumberLit:
 						id, err = strconv.ParseInt(expr.Value, 10, 64)
+						if r.ShardingAlgorithm != nil {
+							keyFind = true
+							if value == nil {
+								value = id
+							}
+							return nil
+						}
 						if err != nil {
 							return err
 						}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
有些情况下，我们的自增id不一定是int64，有可能是其他类型，比如uint64或者uint32，使用主键分表会报类型错误, 修改如果config里有ShardingAlgorithm方法接收字段，则id的查询结果会回到这个方法来实现表后缀名修改
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->
使用案例
```
type Order struct {
	ID      uint64 `gorm:"primarykey"`
	UserID  int64
	Product string
	Deleted gorm.DeletedAt
}

middleware = Register(Config{
		DoubleWrite:         true,
		ShardingKey:         "id",
		NumberOfShards:      4,
                ShardingAlgorithm: func(columnValue any) (suffix string, err error) {
			switch value := columnValue.(type) {
			case uint64, int64:
				return fmt.Sprintf("_%01d", cast.ToUint64(value)%4), nil
			default:
				return "", errors.New("invalid column value")
			}
		},
		PrimaryKeyGenerator: PKCustom,
		PrimaryKeyGeneratorFn: func(_ int64) int64 {
			return 0
		},
	}, &Order{})

db.Use(middleware)
```
