### PR TITLE
fix: result.RowsAffected cause panic when result is nil

### DIFF
--- a/conn_pool.go
+++ b/conn_pool.go
@@ -40,7 +40,10 @@ func (pool ConnPool) ExecContext(ctx context.Context, query string, args ...any)
 			if r.DoubleWrite {
 				pool.sharding.Logger.Trace(ctx, curTime, func() (sql string, rowsAffected int64) {
 					result, _ := pool.ConnPool.ExecContext(ctx, ftQuery, args...)
-					rowsAffected, _ = result.RowsAffected()
+					if result != nil {
+						rowsAffected, _ = result.RowsAffected()
+					}
+
 					return pool.sharding.Explain(ftQuery, args...), rowsAffected
 				}, pool.sharding.Error)
 			}
@@ -50,7 +53,10 @@ func (pool ConnPool) ExecContext(ctx context.Context, query string, args ...any)
 	var result sql.Result
 	result, err = pool.ConnPool.ExecContext(ctx, stQuery, args...)
 	pool.sharding.Logger.Trace(ctx, curTime, func() (sql string, rowsAffected int64) {
-		rowsAffected, _ = result.RowsAffected()
+		if result != nil {
+			rowsAffected, _ = result.RowsAffected()
+		}
+
 		return pool.sharding.Explain(stQuery, args...), rowsAffected
 	}, pool.sharding.Error)
 


### PR DESCRIPTION

当 result 为 nil 时，会导致 panic
比如 MySQL max_allowed_packet 默认为 64MB，如果数据包长度超过 64MB，则会导致 panic。可复现示例如下
```go
package main

import (
	"log"
	"strings"
	"time"

	"gorm.io/driver/mysql"
	"gorm.io/gorm"
	"gorm.io/sharding"
)

type Foo struct {
	ID        int64 `gorm:"primaryKey;autoIncrement"`
	Name      string
	CreatedAt time.Time
	UpdatedAt time.Time
}

type Bar struct {
	ID        int64 `gorm:"primaryKey;autoIncrement"`
	Name      string
	CreatedAt time.Time
	UpdatedAt time.Time
}

func (Foo) TableName() string {
	return "foo"
}

func (Bar) TableName() string {
	return "bar"
}

func main() {
	db, err := gorm.Open(mysql.Open("root:123456@tcp(127.0.0.1:3306)/test?charset=utf8mb4&parseTime=True&loc=Local"))
	if err != nil {
		log.Fatalln(err)
	}

	db.Use(sharding.Register(sharding.Config{
		ShardingKey:         "id",
		NumberOfShards:      2,
		PrimaryKeyGenerator: sharding.PKSnowflake,
	}, Foo{}))

	db.AutoMigrate(&Foo{}, &Bar{})

	err = db.Create(&Bar{
		Name: strings.Repeat("1", 64*1024*1024+1),
	}).Error
	if err != nil {
		log.Fatalln(err)
	}
}

```